### PR TITLE
Fallback to common language

### DIFF
--- a/app-localize-behavior.html
+++ b/app-localize-behavior.html
@@ -232,8 +232,13 @@ Polymer.AppLocalizeBehavior = {
 
     return function() {
       var key = arguments[0];
-      if (!key || !resources || !language || !resources[language])
+      if (!key || !resources || !language)
         return;
+      if (!resources[language])
+        language = language.split('-')[0]; // e.g. when using 'en-US' as language fallback to 'en' when 'en-US' is not available
+      if (!resources[language])
+        return;
+      
 
       // Cache the key/value pairs for the same language, so that we don't
       // do extra work if we're just reusing strings across an application.


### PR DESCRIPTION
e.g. when using 'en-US' as language fallback to 'en' when 'en-US' is not available